### PR TITLE
Condition contains

### DIFF
--- a/Model/Condition.cs
+++ b/Model/Condition.cs
@@ -87,7 +87,7 @@ namespace Granfeldt
     XmlInclude(typeof(ConditionIsPresent)), XmlInclude(typeof(ConditionIsNotPresent)),
     XmlInclude(typeof(ConditionAreEqual)), XmlInclude(typeof(ConditionAreNotEqual)),
     XmlInclude(typeof(ConditionIsTrue)), XmlInclude(typeof(ConditionIsFalse)),
-    XmlInclude(typeof(ConditionContains)),
+    XmlInclude(typeof(ConditionContains)), XmlInclude(typeof(ConditionNotContains)),
     XmlInclude(typeof(ConditionIsNotTrue)),
     XmlInclude(typeof(ConditionIsDNEqual)),
     XmlInclude(typeof(ConditionIsDNNotEqual)),
@@ -325,6 +325,14 @@ namespace Granfeldt
                 Tracer.TraceInformation("Condition failed (Reason: Metaverse multivalue contains no elements) {0}", this.Description);
                 return false;
             }
+        }
+    }
+
+    public class ConditionNotContains : ConditionContains
+    {
+        public override bool Met(MVEntry mventry, CSEntry csentry)
+        {
+            return !base.Met(mventry, csentry);
         }
     }
 

--- a/Model/Condition.cs
+++ b/Model/Condition.cs
@@ -302,6 +302,7 @@ namespace Granfeldt
     {
         public string MVAttribute;
         public string Pattern;
+        public bool CaseSensitive;
 
         public override bool Met(MVEntry mventry, CSEntry csentry)
         {
@@ -313,8 +314,11 @@ namespace Granfeldt
 
             if (mventry[this.MVAttribute].Values?.Count > 0)
             {
-                var entries = mventry[this.MVAttribute].Values.Cast<string>();
-                return entries.Any(x => String.Equals(x, Pattern, StringComparison.CurrentCultureIgnoreCase));
+                var cmpOptions = StringComparison.CurrentCulture;
+                if (!CaseSensitive) { cmpOptions = StringComparison.CurrentCultureIgnoreCase; }
+
+                var entries = mventry[this.MVAttribute].Values.ToStringArray();
+                return entries.Any(x => String.Equals(x, Pattern, cmpOptions));
             }
             else
             {


### PR DESCRIPTION
Resubmitting pr with inverse condition. We are using this condition for provisioning users based on a multi-value indexed string attribute ProvisionTo.  This allows us to programmatically add and remove connector names with AMCA or MIM Service to provision/deprovision users without having to extend metaverse schema.