### PR TITLE
Added random password generator helper.

### DIFF
--- a/Model/Helpers.cs
+++ b/Model/Helpers.cs
@@ -1,13 +1,16 @@
 ﻿// october 12, 2015 | soren granfeldt
 //	- added for future implementation
 
+using System;
+
 namespace Granfeldt
 {
 	using System;
 	using System.Collections.Generic;
 	using System.Diagnostics;
 	using System.Linq;
-	using System.Text;
+    using System.Security.Cryptography;
+    using System.Text;
 	using System.Threading.Tasks;
 	using System.Xml.Serialization;
 
@@ -55,4 +58,60 @@ namespace Granfeldt
 		}
 	}
 
+    public class HelperValueRandomPassword : HelperValue
+    {
+        public int Length = default(int);
+        public string Value;
+        public override string GetValue {
+            get {
+                if (Length == default(int)) Length = 54;
+                return RndHelper.CreateRandomPassword(Length);
+            }
+        }
+        public override void Generate()
+        {
+            base.Generate();
+        }
+    }
+}
+
+internal static class RndHelper
+{
+    internal static string CreateRandomPassword(int passwordLength = 54)
+    {
+        string allowedChars = "abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNOPQRSTUVWXYZ0123456789*&!@$?_-,./?@#()";
+        var chars = new char[passwordLength];
+
+        for (int i = 0; i < passwordLength; i++)
+        {
+            chars[i] = allowedChars[SecureInt(0, allowedChars.Length - 1)];
+        }
+
+        return new string(chars);
+    }
+    private static System.Security.Cryptography.RNGCryptoServiceProvider provider;
+    private static int SecureInt()
+    {
+        if (provider == null) provider = new System.Security.Cryptography.RNGCryptoServiceProvider();
+        var byteArray = new byte[4];
+        provider.GetBytes(byteArray);
+
+        //convert 4 bytes to an integer
+        return BitConverter.ToInt32(byteArray, 0);
+    }
+    private static int SecureInt(int min, int max)
+    {
+        if (max < min)
+        {
+            // Exceptions suck so we'll just swap these values, the range is the same.
+            var tmax = min;
+            min = max;
+            max = tmax;
+        }
+        int seed = default(int);
+        do {
+            seed = SecureInt();
+        } while (seed < min);
+        return (seed % (max - min + 1)) + min;
+    }
 }

--- a/Model/Rule.cs
+++ b/Model/Rule.cs
@@ -64,7 +64,8 @@ namespace Granfeldt
 
 		[XmlArrayItem("Constant", Type = typeof(HelperValueConstant))]
 		[XmlArrayItem("ScopedGuid", Type = typeof(HelperValueScopedGuid))]
-		public List<HelperValue> Helpers;
+        [XmlArrayItem("RandomPassword", Type = typeof(HelperValueRandomPassword))]
+        public List<HelperValue> Helpers;
 
 		public string SourceObject;
 		public string TargetManagementAgentName;


### PR DESCRIPTION
Helper function that generates a random password of specified length each time it's called. System.Security.Cryptography is used rather than System.Random for stronger randomness guarantees. Passwords are created from a fixed set of characters which limits the potential randomness but maintains compatibility with some legacy systems our sync service is connected to but can be offset by specifying longer passwords.

Here's an example rule using the password helper to provision person objects in an LDS app partition:

```
<Rule>
    <Name>User Provision to CA LDS</Name>
    <Description>Provision users to the CA LDS instance</Description>
    <TargetManagementAgentName xsi:type="xsd:string">CA LDS</TargetManagementAgentName>
    <Enabled>true</Enabled>
    <SourceObject>person</SourceObject>
    <TargetObject>user</TargetObject>
    <Action>Provision</Action>
    
    <Helpers>
    <RandomPassword Name="RndPassword" Length="48"></RandomPassword>
    </Helpers>
    
    <Conditions>    
    <ConditionBase xsi:type="ConditionContains">
        <Description>The provisionTo attribute must contain CA</Description>
        <CaseSensitive>false</CaseSensitive>
        <MVAttribute>provisionTo</MVAttribute>
        <Pattern>CA</Pattern>
    </ConditionBase
    </Conditions>
    <InitialFlows>
    <AttributeFlowBase xsi:type="AttributeFlowConstant">
        <EscapedCN>CN=#mv:accountName#</EscapedCN>
        <Constant>#param:EscapedCN#,CN=Users,CN=Access,CN=CA,DC=Identity,DC=PVT</Constant>
        <Target>[DN]</Target>
    </AttributeFlowBase>
    <AttributeFlowBase xsi:type="AttributeFlowAttribute">
        <Source>accountName</Source>
        <Target>cn</Target>
    </AttributeFlowBase>

    <!-- Setting random password allows provisioning the user Enabled in one shot -->
    <AttributeFlowBase xsi:type="AttributeFlowConstant">
        <Constant>#helper:RndPassword#</Constant>
        <Target>unicodePwd</Target>
    </AttributeFlowBase>
    <AttributeFlowBase xsi:type="AttributeFlowConstant">
        <Constant>false</Constant>
        <Target>msDS-UserAccountDisabled</Target>
    </AttributeFlowBase>
    </InitialFlows>
</Rule>
```